### PR TITLE
Update pack.html

### DIFF
--- a/pack.html
+++ b/pack.html
@@ -98,5 +98,5 @@ copyleft licenses in use by the libraries.</p>
 
 <p>The source code for the installer, and scripts to pull in the
 library code and build the whole package, can be found
-in <a href="https://github.org/vamp-plugins/vamp-plugin-pack/">the
+in <a href="https://github.com/vamp-plugins/vamp-plugin-pack/">the
 repository</a> for this project.</p>


### PR DESCRIPTION
Fix GitHub url to `github.com` instead of `github.org`

Hey @cannam — I was browsing through the website today and stumbled upon a link that looked wrong to me.

<img width="988" alt="image" src="https://github.com/user-attachments/assets/5d82cc2f-e7e6-48ef-9508-673c743be09f">

> Clicking on it generated this warning on my browser — which seemed scary — then I looked again and noticed it was attempting to go to github.org instead of github.com

Opened this PR with a patch to help, feel free to ignore or accept in case I was right!

Cheers and thank you!